### PR TITLE
pip-license-checker

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,27 @@
+on: push
+jobs:
+  license_check:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 0
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Get explicit and transitive dependencies
+      run: |
+        pip install -r requirements.txt
+        pip freeze > requirements-all.txt
+    - name: Check python
+      id: license_check_report
+      uses: pilosus/action-pip-license-checker@v0.5.0
+      with:
+        requirements: 'requirements-all.txt'
+        fail: 'Copyleft,Error,Other'
+        exclude: 'pylint.*'
+    - name: Print report
+      if: ${{ always() }}
+      run: echo "${{ steps.license_check_report.outputs.report }}"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -13,7 +13,7 @@ jobs:
         python-version: '3.8'
     - name: Get explicit and transitive dependencies
       run: |
-        pip install -r requirements.txt
+        pip install -r prod_requirements.txt
         pip freeze > requirements-all.txt
     - name: Check python
       id: license_check_report


### PR DESCRIPTION
I found [this](https://github.com/pilosus/action-pip-license-checker) easy to use GitHub action. What do you think?

Should we run the action just on PRs?

See #17 