### PR TITLE
refactor: re-introduce settings.py and manage.py

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         requirements: 'requirements-all.txt'
         fail: 'Copyleft,Error,Other'
-        exclude: 'pylint.*'
+        exclude: 'pylint.*|text-unidecode.*'
     - name: Print report
       if: ${{ always() }}
       run: echo "${{ steps.license_check_report.outputs.report }}"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -20,7 +20,7 @@ jobs:
       uses: pilosus/action-pip-license-checker@v0.5.0
       with:
         requirements: 'requirements-all.txt'
-        fail: 'Copyleft,Error,Other'
+        fail: 'StrongCopyleft,NetworkCopyleft,Error,Other'
         exclude: 'pylint.*|text-unidecode.*'
     - name: Print report
       if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dmypy.json
 
 # Generated / Compiled  Frontend parts
 /omap/frontend/static/css/dist
+
+!site

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,7 @@ def pytest_configure():
     We have to use this custom loading for the django "context"
     as we have no settings.py
     """
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omap.modules.base_settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "site.settings")
     os.environ.setdefault("OMAP_MODULES", "omap_core")
     from omap.modules import modules
 

--- a/conftest.py
+++ b/conftest.py
@@ -6,8 +6,8 @@ def pytest_configure():
     We have to use this custom loading for the django "context"
     as we have no settings.py
     """
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "site.settings")
-    os.environ.setdefault("OMAP_MODULES", "omap_core")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omap_site.settings")
+    os.environ.setdefault("OMAP_MODULES", "")
     from omap.modules import modules
 
     modules.configure_modules()

--- a/manage.py
+++ b/manage.py
@@ -3,17 +3,10 @@
 import os
 import sys
 
-from omap.modules import modules
-
 
 def main():
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omap_site.settings")
-    # Here we set the OMAP_MODULES env varible, if not set
-    os.environ.setdefault("OMAP_MODULES", "")
-
-    # Here we inject our custom settings
-    modules.configure_modules()
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/omap/assets/apps.py
+++ b/omap/assets/apps.py
@@ -4,3 +4,5 @@ from django.apps import AppConfig
 class OmapAssetsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "omap.assets"
+
+    url_prefix = "assets"

--- a/omap/assets/urls.py
+++ b/omap/assets/urls.py
@@ -1,8 +1,9 @@
-from django.conf.urls import url
+from django.urls import path
 
-from omap.core import views
+from omap.assets import views
 
 app_name = "assets"
+
 urlpatterns = [
-    url("", views.demo),
+    path("", views.demo, name="assets/home"),
 ]

--- a/omap/core/apps.py
+++ b/omap/core/apps.py
@@ -4,5 +4,3 @@ from django.apps import AppConfig
 class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "omap.core"
-
-    url_prefix = "core"

--- a/omap/core/urls.py
+++ b/omap/core/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import path
 
 from omap.core import views
 
 app_name = "core"
 
 urlpatterns = [
-    url("tw", views.TailwindDemoView.as_view()),
-    url("", views.demo),
+    path("", views.demo),
+    path("tw", views.TailwindDemoView.as_view()),
 ]

--- a/omap/modules/omap_module_registry.py
+++ b/omap/modules/omap_module_registry.py
@@ -3,11 +3,13 @@ from omap.modules.modules import ModuleConfig
 
 class OmapCore(ModuleConfig):
     """
-    Core Module of the OMAP
+    Example Module for OMAP
     """
 
     module_name = "omap_core"
     module_version = "0.1.0"
-    pip_dependencies = ["django-tailwind==3.1.1"]
-    django_apps = ["omap.frontend", "omap.core", "omap.assets", "tailwind"]
-    settings_entries = {"TAILWIND_APP_NAME": "omap/frontend"}
+    django_apps = []
+
+    # pip_dependencies = ["django-tailwind==3.1.1"]
+    # django_apps = ["omap.frontend", "omap.core", "omap.assets", "tailwind"]
+    # settings_entries = {"TAILWIND_APP_NAME": "omap/frontend"}

--- a/omap_site/__init__.py
+++ b/omap_site/__init__.py
@@ -1,0 +1,4 @@
+"""
+This module contains all files for a django deployment 'site'.
+When called via the manage.py command, this folder is used as regular django setup.
+"""

--- a/omap_site/asgi.py
+++ b/omap_site/asgi.py
@@ -12,7 +12,7 @@ import os
 from django.core.asgi import get_asgi_application
 from omap.modules import modules
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omap.modules.base_settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omap_site.settings")
 modules.configure_modules()
 
 application = get_asgi_application()

--- a/omap_site/settings.py
+++ b/omap_site/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
@@ -41,6 +41,13 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    # OMAP and Dependencies
+    # 3rd Party
+    "tailwind",
+    # OMAP
+    "omap.frontend",
+    "omap.core",
+    "omap.assets",
 ]
 
 MIDDLEWARE = [
@@ -52,7 +59,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
-ROOT_URLCONF = "omap.modules.module_urls"
+ROOT_URLCONF = "omap_site.urls"
 
 TEMPLATES = [
     {
@@ -69,8 +76,8 @@ TEMPLATES = [
         },
     },
 ]
-WSGI_APPLICATION = "omap.modules.wsgi.application"
-ASGI_APPLICATION = "omap.modules.wsgi.application"
+WSGI_APPLICATION = "omap_site.wsgi.application"
+ASGI_APPLICATION = "omap_site.asgi.application"
 # Password validation
 # https://docs.djangoproject.com/en/4.0/ref/settings/#auth-password-validators
 
@@ -113,3 +120,6 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 INTERNAL_IPS = [
     "127.0.0.1",
 ]
+
+# Needed by Tailwind Plugin
+TAILWIND_APP_NAME = "omap/frontend"

--- a/omap_site/urls.py
+++ b/omap_site/urls.py
@@ -3,14 +3,15 @@ import logging
 
 from django.apps import apps
 from django.conf import settings
-from django.conf.urls import url, include
+from django.urls import path, include
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import path
+
+from omap.core import urls as core_urls
 
 
 def dynamic_url():
-    _urlpatterns = [url(r"admin/", admin.site.urls)] + (
+    _urlpatterns = [path("", include(core_urls)), path(r"admin/", admin.site.urls)] + (
         static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
         if settings.MEDIA_ROOT
         else []

--- a/omap_site/wsgi.py
+++ b/omap_site/wsgi.py
@@ -10,7 +10,9 @@ https://docs.djangoproject.com/en/3.1/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from omap.modules import modules
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omap.modules.base_settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omap_site.settings")
+modules.configure_modules()
 
 application = get_wsgi_application()

--- a/prod_requirements.txt
+++ b/prod_requirements.txt
@@ -1,3 +1,3 @@
-django==3.2.12
+-r requirements.txt
 gunicorn==20.0.4
 uvicorn==0.17.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+django==3.2.12
+django-tailwind==3.1.1
+

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 python manage.py migrate
-gunicorn -k uvicorn.workers.UvicornWorker omap.modules.asgi --bind :8000 --enable-stdio-inheritance
+gunicorn -k uvicorn.workers.UvicornWorker omap_site.asgi --bind :8000 --enable-stdio-inheritance


### PR DESCRIPTION
Now all core modules are already in settings.py and a clean start already spawns a base instance.
omap.py can now be used to load the modules additionally.